### PR TITLE
CI: run ruff, mypy, pytest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,44 @@
+name: CI - Lint, Typecheck, Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff mypy pytest
+          if [ -f backend/requirements.txt ]; then pip install -r backend/requirements.txt; fi
+
+      - name: Run ruff
+        run: |
+          echo "Running ruff checks"
+          python -m ruff check .
+
+      - name: Run mypy
+        run: |
+          echo "Running mypy"
+          python -m mypy .
+
+      - name: Run backend tests
+        working-directory: backend
+        run: |
+          echo "Running backend pytest"
+          pytest -q
 name: CI
 
 on:

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,7 +11,7 @@ disallow_untyped_defs = False
 disallow_incomplete_defs = False
 check_untyped_defs = False
 no_implicit_optional = False
-exclude = ^(scripts(/dev)?/.*|tools/.*)
+exclude = ^(scripts(/dev)?/.*|tools/.*|backups/.*|rewrite-preview-local/.*)
 
 [mypy-backend.main]
 ignore_errors = True


### PR DESCRIPTION
Adds CI workflow (.github/workflows/ci.yml) to run ruff, mypy and backend pytest. Also updates mypy.ini to exclude backup and rewrite-preview bundles so mypy can run at repo root.