### PR TITLE
feat(control): safer frontend start/stop

### DIFF
--- a/backend/tests/test_control_endpoints.py
+++ b/backend/tests/test_control_endpoints.py
@@ -1,0 +1,60 @@
+import os
+from types import SimpleNamespace
+from fastapi.testclient import TestClient
+import backend.main as main
+
+client = TestClient(main.app)
+
+
+def test_control_status_monkeypatched(monkeypatch):
+    # No frontend running
+    monkeypatch.setattr(main, "_detect_frontend_port", lambda: None)
+    resp = client.get("/control/api/status")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "backend" in data and "frontend" in data
+
+
+def test_control_start_npm_missing(monkeypatch):
+    # Ensure port not open so start path proceeds
+    monkeypatch.setattr(main, "_is_port_open", lambda host, port, timeout=0.5: False)
+
+    # Make frontend dir exist for the check in control_start
+    orig_isdir = os.path.isdir
+
+    def fake_isdir(p):
+        if "frontend" in str(p):
+            return True
+        return orig_isdir(p)
+
+    monkeypatch.setattr(os.path, "isdir", fake_isdir)
+
+    # Simulate npm not found
+    monkeypatch.setattr(main, "_resolve_npm_command", lambda: None)
+
+    resp = client.post("/control/api/start")
+    assert resp.status_code in (400, 500)
+    data = resp.json()
+    assert (
+        data.get("message")
+        == "npm not found. Please install Node.js and npm (https://nodejs.org/)"
+    )
+
+
+def test_control_stop_kills_pids(monkeypatch):
+    # Ensure no tracked FRONTEND_PROCESS
+    main.FRONTEND_PROCESS = None
+
+    # Return a PID for the frontend port scan
+    monkeypatch.setattr(main, "_find_pids_on_port", lambda port: [12345] if port == main.FRONTEND_PORT_PREFERRED else [])
+
+    # Fake subprocess.run to always succeed for taskkill
+    def fake_run(*args, **kwargs):
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main.subprocess, "run", fake_run)
+
+    resp = client.post("/control/api/stop")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("success") is True

--- a/backend/tests/test_control_start_branches.py
+++ b/backend/tests/test_control_start_branches.py
@@ -1,0 +1,110 @@
+import os
+from types import SimpleNamespace
+from fastapi.testclient import TestClient
+import backend.main as main
+
+client = TestClient(main.app)
+
+
+def test_control_start_success(monkeypatch):
+    # Ensure frontend not already running
+    monkeypatch.setattr(main, "_is_port_open", lambda host, port, timeout=0.5: False)
+
+    # Make frontend dir exist and node_modules present
+    orig_isdir = os.path.isdir
+    monkeypatch.setattr(os.path, "isdir", lambda p: True if ("frontend" in str(p) and "node_modules" not in str(p)) or "node_modules" in str(p) else orig_isdir(p))
+
+    # Simulate npm found
+    monkeypatch.setattr(main, "_resolve_npm_command", lambda: "npm")
+
+    # Simulate npm -v success
+    def fake_run_version(args, cwd=None, stdout=None, stderr=None, shell=False, check=False, timeout=None, text=None):
+        if args and args[1] == "-v":
+            return SimpleNamespace(returncode=0, stdout="9.0.0\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main.subprocess, "run", fake_run_version)
+
+    # Fake Popen that sets port open after creation
+    created = {"started": False}
+
+    class FakeProc:
+        def __init__(self):
+            self.pid = 99999
+
+        def poll(self):
+            return None
+
+    def fake_popen(args, cwd=None, shell=False, stdout=None, stderr=None, text=None, **kwargs):
+        created["started"] = True
+        # after starting, simulate that port is open
+        monkeypatch.setattr(main, "_is_port_open", lambda host, port, timeout=0.5: True)
+        return FakeProc()
+
+    monkeypatch.setattr(main.subprocess, "Popen", fake_popen)
+
+    resp = client.post("/control/api/start")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data.get("success") is True
+    assert "port" in data
+
+
+def test_control_start_install_failure(monkeypatch, tmp_path):
+    # Ensure frontend not already running
+    monkeypatch.setattr(main, "_is_port_open", lambda host, port, timeout=0.5: False)
+
+    # Frontend dir exists but node_modules missing
+    monkeypatch.setattr(os.path, "isdir", lambda p: True if ("frontend" in str(p) and "node_modules" not in str(p)) else False)
+
+    # npm found
+    monkeypatch.setattr(main, "_resolve_npm_command", lambda: "npm")
+
+    # Version check succeeds
+    def fake_run(args, cwd=None, stdout=None, stderr=None, shell=False, check=False, timeout=None, text=None):
+        # npm -v
+        if args and args == ["npm", "-v"]:
+            return SimpleNamespace(returncode=0, stdout="9.0.0\n", stderr="")
+        # npm ci fails
+        if args and args[:2] == ["npm", "ci"]:
+            return SimpleNamespace(returncode=1, stdout="ci failed", stderr="")
+        # fallback npm install also fails
+        if args and args[:2] == ["npm", "install"]:
+            return SimpleNamespace(returncode=1, stdout="install failed", stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(main.subprocess, "run", fake_run)
+
+    resp = client.post("/control/api/start")
+    # Expect failure due to dependency install failing and normalized message
+    assert resp.status_code == 500
+    data = resp.json()
+    assert data.get("message") == "Failed to install frontend dependencies"
+
+
+def test_control_start_process_terminated(monkeypatch):
+    # Ensure frontend not already running
+    monkeypatch.setattr(main, "_is_port_open", lambda host, port, timeout=0.5: False)
+
+    # frontend dir and node_modules present
+    monkeypatch.setattr(os.path, "isdir", lambda p: True)
+
+    monkeypatch.setattr(main, "_resolve_npm_command", lambda: "npm")
+
+    # version_check ok
+    monkeypatch.setattr(main.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=0, stdout="9.0.0\n"))
+
+    # Popen that has already terminated
+    class DeadProc:
+        def __init__(self):
+            self.pid = 11111
+
+        def poll(self):
+            return 1
+
+    monkeypatch.setattr(main.subprocess, "Popen", lambda *a, **k: DeadProc())
+
+    resp = client.post("/control/api/start")
+    assert resp.status_code == 500
+    data = resp.json()
+    assert data.get("message") == "Frontend process terminated unexpectedly"


### PR DESCRIPTION
Summary:\n- Replace unsafe shell subprocess calls in backend control endpoints with list-style calls (shell=False).\n- Normalize user-facing /control API messages so behavior/tests are platform-agnostic.\n- Add Windows creationflags and close_fds handling for Popen.\n- Guard RequestID middleware registration.\n- Add unit tests for control /start branches (install failure, terminated, success).\n\nValidation: local ruff, mypy and full backend pytest were run and passed.\nNotes: CI will run additional checks; the branch is feat/control-start-safety.\n