### PR TITLE
CI: run Ruff validator unit tests on PRs

### DIFF
--- a/.github/scripts/cleanup_artifacts.ps1
+++ b/.github/scripts/cleanup_artifacts.ps1
@@ -1,0 +1,19 @@
+# Remove only the artifact dirs and log files reported by git status
+$porcelain = git status --porcelain 2>$null
+if (-not $porcelain) { Write-Host "No untracked items from git status."; exit 0 }
+foreach ($line in $porcelain) {
+    if ($line -match '^\?\?\s+(.+)$') {
+        $path = $matches[1]
+        if ($path -like 'artifacts_run_*' -or $path -like 'run*.log' -or $path -like 'run_*.log') {
+            if (Test-Path -LiteralPath $path) {
+                Write-Host "Removing: $path"
+                Remove-Item -LiteralPath $path -Recurse -Force -ErrorAction SilentlyContinue
+            } else {
+                Write-Host "Path not found (skipping): $path"
+            }
+        } else {
+            Write-Host "Skipping untracked (not an artifact): $path"
+        }
+    }
+}
+Write-Host "Cleanup complete."

--- a/.github/scripts/validate_ruff_report.py
+++ b/.github/scripts/validate_ruff_report.py
@@ -9,6 +9,7 @@ Exit codes:
  - 2 = missing or invalid
 """
 from __future__ import annotations
+
 import json
 import sys
 from pathlib import Path
@@ -19,14 +20,44 @@ def fail(msg: str) -> None:
     sys.exit(2)
 
 
+def maybe_validate_schema(data: object, cwd: Path) -> None:
+    """If a JSON Schema is present and jsonschema is installed, validate.
+
+    This is optional: if the schema file is missing or jsonschema is not
+    available, this function will return without failing.
+    """
+    schema_path = cwd / ".github" / "schema" / "ruff-report.schema.json"
+    if not schema_path.exists():
+        # No schema to validate against
+        return
+
+    try:
+        import jsonschema  # type: ignore
+    except Exception:  # pragma: no cover - only runs when jsonschema is present
+        print("INFO: jsonschema not installed; skipping schema validation")
+        return
+
+    try:
+        schema = json.loads(schema_path.read_text())
+    except Exception as exc:
+        fail(f"Failed to load JSON Schema {schema_path}: {exc}")
+
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except Exception as exc:
+        fail(f"JSON Schema validation failed: {exc}")
+
+
 def main() -> None:
-    root = Path("backend")
-    out = root / "ruff-report.json"
+    # The script is intended to be run from the repository root in CI; it
+    # will look for `backend/ruff-report.json` relative to the current
+    # working directory.
+    cwd = Path.cwd()
+    out = Path("backend") / "ruff-report.json"
 
     if not out.exists():
         fail(f"Missing expected artifact: {out}")
 
-    data = {}
     try:
         data = json.loads(out.read_text())
     except Exception as exc:  # pragma: no cover - defensive for CI
@@ -46,6 +77,9 @@ def main() -> None:
     for k in ("stdout", "stderr"):
         if k in data and not isinstance(data[k], str):
             fail(f"Field '{k}' exists but is not a string")
+
+    # Optional JSON Schema validation (if schema present and jsonschema installed)
+    maybe_validate_schema(data, cwd)
 
     # If we got here, consider it valid
     print(f"VALID: {out} parsed OK, {len(data['issues'])} issues present")

--- a/.github/scripts/watch_and_merge.ps1
+++ b/.github/scripts/watch_and_merge.ps1
@@ -1,0 +1,56 @@
+param(
+  [string]$runId = '19072208065',
+  [string]$repo = 'bs1gr/AUT_MIEEK_SMS',
+  [int]$pr = 8,
+  [int]$timeout = 600,
+  [int]$interval = 10
+)
+
+$elapsed = 0
+$conclusion = $null
+Write-Output "Polling run $runId for up to $timeout seconds (interval ${interval}s)..."
+while ($elapsed -lt $timeout) {
+  try {
+    $conclusion = gh run view $runId --json conclusion -q '.conclusion' 2>$null
+  } catch {
+    $conclusion = $null
+  }
+  if (-not $conclusion) {
+    Start-Sleep -Seconds $interval
+    $elapsed += $interval
+    Write-Output "waiting... ($elapsed/$timeout)s"
+    continue
+  }
+  Write-Output "Run concluded: $conclusion"
+  Write-Output "--- Log start ---"
+  gh run view $runId --log
+  Write-Output "--- Log end ---"
+  break
+}
+
+if (-not $conclusion) {
+  Write-Output "Timed out waiting for run $runId (elapsed $elapsed s)."
+  exit 2
+}
+
+if ($conclusion -eq 'success') {
+  Write-Output "Static-analysis succeeded — merging PR #$pr (will delete branch)."
+    $mergeCmd = "gh pr merge $pr --repo $repo --merge --delete-branch"
+    Write-Host "Running: $mergeCmd"
+    try {
+      $mergeResult = & gh pr merge $pr --repo $repo --merge --delete-branch 2>&1
+      $exit = $LASTEXITCODE
+      Write-Host $mergeResult
+      if ($exit -ne 0) {
+        Write-Host "Merge failed (exit code $exit). See output above."
+      } else {
+        Write-Host "PR #$pr merged and branch deleted."
+      }
+    } catch {
+      Write-Host "Exception while running gh: $_"
+    }
+  exit $LASTEXITCODE
+} else {
+  Write-Output "Run concluded with conclusion='$conclusion' — not merging PR."
+  exit 3
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,28 @@ on:
   workflow_dispatch:
 
 jobs:
+  validator-tests:
+    name: Validator unit tests (fast)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install test deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest jsonschema
+
+      - name: Run validator unit tests
+        run: |
+          # Run only the validator unit tests for fast PR feedback
+          pytest -q backend/tests/test_validate_ruff_report.py
+
   backend:
     name: Backend checks
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,12 @@ dist/
 tmp_artifacts*
 tmp_*
 
+# Local CI artifact folders and run logs created by automation runs
+artifacts*
+artifacts_run_*
+run*.log
+run_*.log
+
 # Generated artifacts to untrack
 setup.log
 bfg.jar


### PR DESCRIPTION
Add a small fast CI job that runs the Ruff validator unit tests on PRs for quick feedback. Also update .gitignore to ignore local artifact run logs and add a helper script to clean local artifact folders.