### PR TITLE
ci: fix quick validation vitest reporter

### DIFF
--- a/.github/workflows/quickstart-validation.yml
+++ b/.github/workflows/quickstart-validation.yml
@@ -56,7 +56,9 @@ jobs:
         continue-on-error: true
 
       - name: Quick frontend tests
-        run: cd frontend && npm run test -- --run --reporter=basic
+        # 'basic' reporter is not available in our vitest version and causes startup errors
+        # Use 'dot' for a compact reporter that is supported, or omit the flag to use default
+        run: cd frontend && npm run test -- --run --reporter=dot
         timeout-minutes: 3
 
       - name: Summary


### PR DESCRIPTION
Quickstart validation workflow used a non-existent vitest reporter 'basic' which caused 'Quick frontend tests' to fail. Change reporter to 'dot' to avoid startup errors in CI.