### PR TITLE
ci: install Python 3.11 on Windows smoke runner

### DIFF
--- a/.github/workflows/native-setup-smoke.yml
+++ b/.github/workflows/native-setup-smoke.yml
@@ -15,6 +15,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          check-latest: true
+          cache: 'pip'
+
       - name: Run native setup (smoke)
         shell: pwsh
         run: |


### PR DESCRIPTION
Ensure the Windows smoke job installs Python 3.11 (actions/setup-python@v5) before running NATIVE.ps1 -Setup so the smoke test prerequisites pass. This protects against runner images missing the required Python version and avoids false-negative failures.