### PR TITLE
fix: clean up React hook dependencies

### DIFF
--- a/src/frontend/frontend/src/components/ControlPanel.tsx
+++ b/src/frontend/frontend/src/components/ControlPanel.tsx
@@ -417,7 +417,7 @@ function formatUptime(seconds: number): string {
       clearInterval(interval);
       if (uptimeTimerRef.current) clearInterval(uptimeTimerRef.current);
     };
-  }, [fetchStatus, fetchDiagnostics, fetchPorts, fetchEnvironment]);
+  }, [fetchStatus]);
 
   // Tab change effects
   useEffect(() => {

--- a/src/frontend/frontend/src/components/admin/AdminUsersPanel.tsx
+++ b/src/frontend/frontend/src/components/admin/AdminUsersPanel.tsx
@@ -117,6 +117,7 @@ const AdminUsersPanel: React.FC<AdminUsersPanelProps> = ({ onToast }) => {
       setAccessDenied(true);
       return;
     }
+    setAccessDenied(false);
     void loadUsers();
   }, [loadUsers, user, accessToken]);
 


### PR DESCRIPTION
Resolves linting warnings in ControlPanel and AdminUsersPanel components by fixing useEffect dependencies.